### PR TITLE
Feature: support EAP MD5

### DIFF
--- a/eap/eap.go
+++ b/eap/eap.go
@@ -19,6 +19,9 @@ const (
 	EapTypeIdentity EapType = iota + 1
 	EapTypeNotification
 	EapTypeNak
+	EapTypeMD5
+	EapTypeOTP
+	EapTypeGTC
 	EapTypeAkaPrime EapType = 50
 	EapTypeExpanded EapType = 254
 )
@@ -27,6 +30,9 @@ var typeStr = map[EapType]string{
 	EapTypeIdentity:     "EAP-Identity",
 	EapTypeNotification: "EAP-Notification",
 	EapTypeNak:          "EAP-Nak",
+	EapTypeMD5:          "EAP-MD5-Challenge",
+	EapTypeOTP:          "EAP-OTP",
+	EapTypeGTC:          "EAP-GTC",
 	EapTypeAkaPrime:     "EAP-AKA'",
 	EapTypeExpanded:     "EAP-Expanded",
 }
@@ -145,6 +151,8 @@ func (eap *EAP) Unmarshal(b []byte) error {
 			eapTypeData = new(EapNotification)
 		case EapTypeNak:
 			eapTypeData = new(EapNak)
+		case EapTypeMD5:
+			eapTypeData = new(EapMD5)
 		case EapTypeAkaPrime:
 			eapTypeData = new(EapAkaPrime)
 		case EapTypeExpanded:

--- a/eap/eap_aka_prime_test.go
+++ b/eap/eap_aka_prime_test.go
@@ -170,6 +170,21 @@ func TestEapAkaPrimeSetGetAttr(t *testing.T) {
 			value:     []byte{0x12},
 			expectErr: true,
 		},
+		{
+			name:     "Set AT_AUTS",
+			attrType: AT_AUTS,
+			value: []byte{
+				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+				0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+			},
+			expectErr: false,
+		},
+		{
+			name:      "Set AT_AUTS with invalid length",
+			attrType:  AT_AUTS,
+			value:     []byte{0x01, 0x02, 0x03},
+			expectErr: true,
+		},
 	}
 
 	for _, tc := range tcs {
@@ -392,6 +407,26 @@ func TestEapAkaPrimeMarshal(t *testing.T) {
 			},
 			expectErr: false,
 		},
+		{
+			name:    "AT_AUTS basic",
+			subType: SubtypeAkaChallenge,
+			attrs: map[EapAkaPrimeAttrType][]byte{
+				AT_AUTS: {
+					0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+					0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+				},
+			},
+			expectedResult: []byte{
+				byte(EapTypeAkaPrime),     // EAP-AKA' type
+				byte(SubtypeAkaChallenge), // Subtype
+				0x00, 0x00,                // Reserved
+				0x04, 0x04, // AT_AUTS type=4, length=4
+				// 14 bytes AUTS
+				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+				0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+			},
+			expectErr: false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -553,6 +588,24 @@ func TestEapAkaPrimeUnmarshal(t *testing.T) {
 			},
 			expectedAttrs: map[EapAkaPrimeAttrType][]byte{
 				AT_NOTIFICATION: {0x12, 0x34},
+			},
+			expectErr: false,
+		},
+		{
+			name: "AT_AUTS basic",
+			rawData: []byte{
+				byte(EapTypeAkaPrime),
+				byte(SubtypeAkaChallenge),
+				0x00, 0x00,
+				0x04, 0x04, // AT_AUTS type=4, length=4
+				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+				0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+			},
+			expectedAttrs: map[EapAkaPrimeAttrType][]byte{
+				AT_AUTS: {
+					0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+					0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+				},
 			},
 			expectErr: false,
 		},

--- a/eap/eap_aka_prime_test.go
+++ b/eap/eap_aka_prime_test.go
@@ -158,6 +158,18 @@ func TestEapAkaPrimeSetGetAttr(t *testing.T) {
 			value:     []byte{0x01},
 			expectErr: true,
 		},
+		{
+			name:      "Set AT_NOTIFICATION with valid length",
+			attrType:  AT_NOTIFICATION,
+			value:     []byte{0x12, 0x34},
+			expectErr: false,
+		},
+		{
+			name:      "Set AT_NOTIFICATION with invalid length",
+			attrType:  AT_NOTIFICATION,
+			value:     []byte{0x12},
+			expectErr: true,
+		},
 	}
 
 	for _, tc := range tcs {
@@ -184,6 +196,8 @@ func TestEapAkaPrimeSetGetAttr(t *testing.T) {
 				require.Equal(t, uint8(1), attr.length)
 			case AT_MAC, AT_RAND, AT_AUTN:
 				require.Equal(t, uint8(5), attr.length)
+			case AT_NOTIFICATION:
+				require.Equal(t, uint8(1), attr.length)
 			}
 		})
 	}
@@ -364,6 +378,20 @@ func TestEapAkaPrimeMarshal(t *testing.T) {
 			},
 			expectErr: false,
 		},
+		{
+			name:    "AT_NOTIFICATION basic",
+			subType: SubtypeAkaNotification,
+			attrs: map[EapAkaPrimeAttrType][]byte{
+				AT_NOTIFICATION: {0x12, 0x34},
+			},
+			expectedResult: []byte{
+				byte(EapTypeAkaPrime),
+				byte(SubtypeAkaNotification),
+				0x00, 0x00,
+				0x0c, 0x01, 0x12, 0x34, // AT_NOTIFICATION (type=12, length=1, value=0x12 0x34)
+			},
+			expectErr: false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -514,6 +542,19 @@ func TestEapAkaPrimeUnmarshal(t *testing.T) {
 				// Missing AT_RAND value
 			},
 			expectErr: true,
+		},
+		{
+			name: "AT_NOTIFICATION basic",
+			rawData: []byte{
+				byte(EapTypeAkaPrime),
+				byte(SubtypeAkaNotification),
+				0x00, 0x00,
+				0x0c, 0x01, 0x12, 0x34, // AT_NOTIFICATION (type=12, length=1, value=0x12 0x34)
+			},
+			expectedAttrs: map[EapAkaPrimeAttrType][]byte{
+				AT_NOTIFICATION: {0x12, 0x34},
+			},
+			expectErr: false,
 		},
 	}
 

--- a/eap/eap_identity.go
+++ b/eap/eap_identity.go
@@ -31,3 +31,12 @@ func (eapIdentity *EapIdentity) Unmarshal(b []byte) error {
 	}
 	return nil
 }
+
+func (eapIdentity *EapIdentity) SetIdentityData(identityData []byte) {
+	eapIdentity.IdentityData = make([]byte, len(identityData))
+	copy(eapIdentity.IdentityData, identityData)
+}
+
+func (eapIdentity *EapIdentity) SetIdentityDataString(identityData string) {
+	eapIdentity.SetIdentityData([]byte(identityData))
+}

--- a/eap/eap_identity_test.go
+++ b/eap/eap_identity_test.go
@@ -79,3 +79,20 @@ func TestEapIdentityUnmarshal(t *testing.T) {
 		})
 	}
 }
+
+func TestEapIdentitySetIdentityData(t *testing.T) {
+	id := EapIdentity{}
+	data := []byte{0x11, 0x22, 0x33}
+	id.SetIdentityData(data)
+	require.Equal(t, data, id.IdentityData)
+	// Ensure it is a copy, not a reference
+	data[0] = 0x99
+	require.NotEqual(t, data, id.IdentityData)
+}
+
+func TestEapIdentitySetIdentityDataString(t *testing.T) {
+	id := EapIdentity{}
+	str := "user01"
+	id.SetIdentityDataString(str)
+	require.Equal(t, []byte(str), id.IdentityData)
+}

--- a/eap/eap_md5.go
+++ b/eap/eap_md5.go
@@ -1,0 +1,94 @@
+package eap
+
+import (
+	"github.com/pkg/errors"
+)
+
+// 0                   1                   2                   3
+// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |  Value-Size   |  Value ...
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |  Name ...
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+// EapMD5 corresponds to EAP Type 4 (MD5-Challenge)
+// RFC 3748 Section 5.4
+var _ EapTypeData = &EapMD5{}
+
+const (
+	EapMD5ChallengeSize = 16 // MD5 challenge is always 16 bytes
+	EapMD5HeaderLen     = 2  // 1 byte Type + 1 byte ValueSize
+	EapMD5MinLen        = 3  // 1 byte Type + 1 byte ValueSize + at least 1 byte Value (but spec requires 16)
+)
+
+type EapMD5 struct {
+	ValueSize uint8  // Value-Size field (should be 16 for MD5)
+	Value     []byte // MD5-Challenge value (16 bytes)
+	Name      string // Optional Name field (variable length)
+}
+
+func (e *EapMD5) Type() EapType {
+	return EapTypeMD5
+}
+
+func (e *EapMD5) Marshal() ([]byte, error) {
+	if e.ValueSize != EapMD5ChallengeSize {
+		return nil, errors.New("EapMD5: ValueSize must be 16")
+	}
+	if len(e.Value) != EapMD5ChallengeSize {
+		return nil, errors.Errorf("EapMD5: Value must be %d bytes, got %d", EapMD5ChallengeSize, len(e.Value))
+	}
+
+	data := []byte{byte(EapTypeMD5), e.ValueSize}
+	data = append(data, e.Value...)
+	if len(e.Name) > 0 {
+		data = append(data, []byte(e.Name)...)
+	}
+	return data, nil
+}
+
+func (e *EapMD5) Unmarshal(b []byte) error {
+	if len(b) < EapMD5MinLen {
+		return errors.New("EapMD5: not enough data")
+	}
+	actualType := EapType(b[0])
+	if actualType != EapTypeMD5 {
+		return errors.Errorf("EapMD5: expect type %s but got %s", EapTypeMD5.String(), actualType.String())
+	}
+
+	e.ValueSize = b[1]
+	if e.ValueSize != EapMD5ChallengeSize {
+		return errors.Errorf("EapMD5: ValueSize must be %d, got %d", EapMD5ChallengeSize, e.ValueSize)
+	}
+	if len(b) < EapMD5HeaderLen+int(e.ValueSize) {
+		return errors.Errorf(
+			"EapMD5: insufficient data, expected at least %d bytes, got %d",
+			EapMD5HeaderLen+int(e.ValueSize), len(b),
+		)
+	}
+
+	e.Value = make([]byte, EapMD5ChallengeSize)
+	copy(e.Value, b[EapMD5HeaderLen:EapMD5HeaderLen+EapMD5ChallengeSize])
+
+	if len(b) > EapMD5HeaderLen+EapMD5ChallengeSize {
+		e.Name = string(b[EapMD5HeaderLen+EapMD5ChallengeSize:])
+	} else {
+		e.Name = ""
+	}
+	return nil
+}
+
+func (e *EapMD5) SetChallengeValue(value []byte) error {
+	if len(value) != EapMD5ChallengeSize {
+		return errors.Errorf("EapMD5: challenge value must be %d bytes, got %d", EapMD5ChallengeSize, len(value))
+	}
+	e.ValueSize = EapMD5ChallengeSize
+	e.Value = make([]byte, EapMD5ChallengeSize)
+	copy(e.Value, value)
+	return nil
+}
+
+func (e *EapMD5) SetName(name string) {
+	e.Name = name
+}

--- a/eap/eap_md5_test.go
+++ b/eap/eap_md5_test.go
@@ -1,0 +1,136 @@
+package eap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	validMD5Challenge = []byte{
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+	}
+	validMD5Name = "testuser"
+	validEapMD5  = EapMD5{
+		ValueSize: EapMD5ChallengeSize,
+		Value:     validMD5Challenge,
+		Name:      validMD5Name,
+	}
+	validEapMD5Bytes = append(
+		append(
+			[]byte{byte(EapTypeMD5), EapMD5ChallengeSize},
+			validMD5Challenge...,
+		),
+		[]byte(validMD5Name)...,
+	)
+)
+
+func TestEapMD5Marshal(t *testing.T) {
+	testcases := []struct {
+		description string
+		eap         EapMD5
+		expMarshal  []byte
+		expErr      bool
+	}{
+		{
+			description: "ValueSize not 16",
+			eap:         EapMD5{ValueSize: 15, Value: make([]byte, 15)},
+			expErr:      true,
+		},
+		{
+			description: "Value length not 16",
+			eap:         EapMD5{ValueSize: 16, Value: make([]byte, 15)},
+			expErr:      true,
+		},
+		{
+			description: "Valid Marshal",
+			eap:         validEapMD5,
+			expMarshal:  validEapMD5Bytes,
+			expErr:      false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := tc.eap.Marshal()
+			if tc.expErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expMarshal, result)
+			}
+		})
+	}
+}
+
+func TestEapMD5Unmarshal(t *testing.T) {
+	testcases := []struct {
+		description string
+		b           []byte
+		expEap      EapMD5
+		expErr      bool
+	}{
+		{
+			description: "Not enough data",
+			b:           []byte{byte(EapTypeMD5), 16},
+			expErr:      true,
+		},
+		{
+			description: "Wrong type",
+			b:           append([]byte{0x00}, make([]byte, 17)...),
+			expErr:      true,
+		},
+		{
+			description: "ValueSize not 16",
+			b:           append([]byte{byte(EapTypeMD5), 15}, make([]byte, 15)...),
+			expErr:      true,
+		},
+		{
+			description: "Insufficient data for challenge",
+			b:           append([]byte{byte(EapTypeMD5), 16}, make([]byte, 10)...), // only 10 bytes for challenge
+			expErr:      true,
+		},
+		{
+			description: "Valid Unmarshal",
+			b:           validEapMD5Bytes,
+			expEap:      validEapMD5,
+			expErr:      false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			var eap EapMD5
+			err := eap.Unmarshal(tc.b)
+			if tc.expErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expEap.ValueSize, eap.ValueSize)
+				require.Equal(t, tc.expEap.Value, eap.Value)
+				require.Equal(t, tc.expEap.Name, eap.Name)
+			}
+		})
+	}
+}
+
+func TestEapMD5SetChallengeValue(t *testing.T) {
+	var eapMD5 EapMD5
+	challenge := make([]byte, 16)
+	err := eapMD5.SetChallengeValue(challenge)
+	require.NoError(t, err)
+	require.Equal(t, uint8(16), eapMD5.ValueSize)
+	require.Equal(t, challenge, eapMD5.Value)
+
+	badChallenge := make([]byte, 15)
+	err = eapMD5.SetChallengeValue(badChallenge)
+	require.Error(t, err)
+}
+
+func TestEapMD5SetName(t *testing.T) {
+	var eapMD5 EapMD5
+	name := "alice"
+	eapMD5.SetName(name)
+	require.Equal(t, name, eapMD5.Name)
+}

--- a/eap/eap_test.go
+++ b/eap/eap_test.go
@@ -87,6 +87,27 @@ var (
 		0x60, 0x9c, 0x9e, 0x20, 0x56, 0x9f, 0xc0, 0x39,
 		0xda, 0x3f, 0x22, 0x2a, 0xb8, 0x56, 0x81, 0x8a,
 	}
+
+	eapMD5 = eap_message.EAP{
+		Code:       eap_message.EapCodeRequest,
+		Identifier: 9,
+		EapTypeData: &eap_message.EapMD5{
+			ValueSize: eap_message.EapMD5ChallengeSize,
+			Value:     []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+			Name:      "testuser",
+		},
+	}
+	eapMD5Byte = append(
+		[]byte{
+			0x01,       // Code
+			0x09,       // Identifier
+			0x00, 0x1e, // Length (30 bytes)
+			0x04, 0x10, // Type and ValueSize
+			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+			0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+		},
+		[]byte("testuser")...,
+	)
 )
 
 func TestEapMarshal(t *testing.T) {
@@ -151,6 +172,12 @@ func TestEapMarshal(t *testing.T) {
 			description: "EapExpanded marshal",
 			eap:         eapExpanded,
 			expMarshal:  eapExpandedByte,
+			expErr:      false,
+		},
+		{
+			description: "EapMD5 marshal",
+			eap:         eapMD5,
+			expMarshal:  eapMD5Byte,
 			expErr:      false,
 		},
 	}
@@ -219,6 +246,12 @@ func TestEapUnmarshal(t *testing.T) {
 			description: "EapExpanded unmarshal",
 			b:           eapExpandedByte,
 			expMarshal:  eapExpanded,
+			expErr:      false,
+		},
+		{
+			description: "EapMD5 unmarshal",
+			b:           eapMD5Byte,
+			expMarshal:  eapMD5,
 			expErr:      false,
 		},
 	}

--- a/message/build.go
+++ b/message/build.go
@@ -44,7 +44,7 @@ func (container *IKEPayloadContainer) BuildEncrypted(nextPayload IkePayloadType,
 	return encrypted
 }
 
-func (container *IKEPayloadContainer) BUildKeyExchange(diffiehellmanGroup uint16, keyExchangeData []byte) {
+func (container *IKEPayloadContainer) BuildKeyExchange(diffiehellmanGroup uint16, keyExchangeData []byte) {
 	keyExchange := new(KeyExchange)
 	keyExchange.DiffieHellmanGroup = diffiehellmanGroup
 	keyExchange.KeyExchangeData = append(keyExchange.KeyExchangeData, keyExchangeData...)


### PR DESCRIPTION
# Add EAP-MD5 (Type 4) Support and Utilities

## Summary

This PR introduces support for the EAP-MD5 (EAP Type 4) protocol, including its marshaling/unmarshaling logic, utility methods for EAP-Identity, and comprehensive unit tests. It also fixes a typo in the `BuildKeyExchange` method name.

## Changes

### 1. EAP-MD5 Support
- Added `EapTypeMD5`, `EapTypeOTP`, and `EapTypeGTC` to EAP type constants and string mapping.
- Implemented the `EapMD5` struct in `eap_md5.go` with:
  - Marshaling and unmarshaling methods.
  - Methods for setting challenge values and names.
- Registered `EapMD5` in the EAP type switch for unmarshaling.

### 2. Unit Tests
- Added `eap_md5_test.go` with tests for:
  - Marshaling and unmarshaling.
  - Utility methods of `EapMD5`.
- Extended `eap_test.go` to include EAP-MD5 test cases.
- Added tests for new EAP-Identity utility methods in `eap_identity_test.go`.

### 3. EAP-Identity Utilities
- Added `SetIdentityData` and `SetIdentityDataString` methods to `EapIdentity` for easier manipulation of identity data.

### 4. Bug Fix
- Fixed a typo in `message/build.go`: renamed `BUildKeyExchange` to `BuildKeyExchange`.


## Testing

- All new and existing unit tests pass.
- EAP-MD5 marshaling and unmarshaling are verified with various edge cases.

--- 