### PR TITLE
fix: eap unmarshal with request and response case

### DIFF
--- a/eap/eap.go
+++ b/eap/eap.go
@@ -141,6 +141,11 @@ func (eap *EAP) Unmarshal(b []byte) error {
 		eap.Code = EapCode(b[0])
 		eap.Identifier = b[1]
 
+		// EAP Request or Response
+		if (eap.Code == EapCodeRequest || eap.Code == EapCodeResponse) && eapPayloadLength < 5 {
+			return errors.New("EAP payload too short for Request/Response: length")
+		}
+
 		// EAP Success or Failure
 		if eapPayloadLength == 4 {
 			return nil


### PR DESCRIPTION
### Description
This PR addresses a vulnerability where the EAP parser incorrectly accepts malformed packets with insufficient length.
This issue was tracked in [issue #938](https://github.com/free5gc/free5gc/issues/938)

### Root Cause
According to RFC 3748, Section 4.1, EAP Request (Code 1) and Response (Code 2) packets MUST include a 1-byte Type field. Therefore, the total length must be at least 5 bytes ($4 \text{ bytes header} + 1 \text{ byte Type}$).
The current implementation allowed a length of $4$ bytes for these codes, resulting in EapTypeData being nil and causing crashes in upstream components.

<img width="1008" height="278" alt="image" src="https://github.com/user-attachments/assets/ee137d2f-f47f-4c7c-9c94-954067af45e2" />

### Changes
• Added a validation check: if the EAP Code is Request or Response, the eapPayloadLength must be $\ge 5$.
• Returns an error if the length is insufficient, preventing nil pointer issues in downstream logic.
