### PR TITLE
Fix payload parser

### DIFF
--- a/eap/eap.go
+++ b/eap/eap.go
@@ -141,6 +141,11 @@ func (eap *EAP) Unmarshal(b []byte) error {
 		eap.Code = EapCode(b[0])
 		eap.Identifier = b[1]
 
+		// EAP Request or Response
+		if (eap.Code == EapCodeRequest || eap.Code == EapCodeResponse) && eapPayloadLength < 5 {
+			return errors.New("EAP payload too short for Request/Response: length")
+		}
+
 		// EAP Success or Failure
 		if eapPayloadLength == 4 {
 			return nil

--- a/message/payload_securityassociation.go
+++ b/message/payload_securityassociation.go
@@ -199,8 +199,8 @@ func (securityAssociation *SecurityAssociation) Unmarshal(b []byte) error {
 			transform.TransformID = binary.BigEndian.Uint16(transformData[6:8])
 			if transformLength > 8 {
 				if len(transformData) < 10 {
-                    return errors.Errorf("Transform: attribute data too short to read Type (length: %d)", len(transformData))
-                }
+					return errors.Errorf("Transform: attribute data too short to read Type (length: %d)", len(transformData))
+				}
 
 				transform.AttributePresent = true
 				transform.AttributeFormat = ((transformData[8] & 0x80) >> 7)
@@ -208,8 +208,8 @@ func (securityAssociation *SecurityAssociation) Unmarshal(b []byte) error {
 
 				if transform.AttributeFormat == 0 {
 					if len(transformData) < 12 {
-                        return errors.Errorf("Transform: attribute data too short to read Length (length: %d)", len(transformData))
-                    }
+						return errors.Errorf("Transform: attribute data too short to read Length (length: %d)", len(transformData))
+					}
 
 					attributeLength := binary.BigEndian.Uint16(transformData[10:12])
 					// bounds checking
@@ -220,9 +220,9 @@ func (securityAssociation *SecurityAssociation) Unmarshal(b []byte) error {
 					copy(transform.VariableLengthAttributeValue, transformData[12:12+attributeLength])
 				} else {
 					if len(transformData) < 12 {
-                        return errors.Errorf("Transform: attribute data too short to read Value (length: %d)", len(transformData))
-                    }
-					
+						return errors.Errorf("Transform: attribute data too short to read Value (length: %d)", len(transformData))
+					}
+
 					transform.AttributeValue = binary.BigEndian.Uint16(transformData[10:12])
 				}
 			}

--- a/message/payload_securityassociation.go
+++ b/message/payload_securityassociation.go
@@ -198,11 +198,19 @@ func (securityAssociation *SecurityAssociation) Unmarshal(b []byte) error {
 			transform.TransformType = transformData[4]
 			transform.TransformID = binary.BigEndian.Uint16(transformData[6:8])
 			if transformLength > 8 {
+				if len(transformData) < 10 {
+                    return errors.Errorf("Transform: attribute data too short to read Type (length: %d)", len(transformData))
+                }
+
 				transform.AttributePresent = true
 				transform.AttributeFormat = ((transformData[8] & 0x80) >> 7)
 				transform.AttributeType = binary.BigEndian.Uint16(transformData[8:10]) & 0x7f
 
 				if transform.AttributeFormat == 0 {
+					if len(transformData) < 12 {
+                        return errors.Errorf("Transform: attribute data too short to read Length (length: %d)", len(transformData))
+                    }
+
 					attributeLength := binary.BigEndian.Uint16(transformData[10:12])
 					// bounds checking
 					if (12 + attributeLength) != transformLength {
@@ -211,6 +219,10 @@ func (securityAssociation *SecurityAssociation) Unmarshal(b []byte) error {
 					}
 					copy(transform.VariableLengthAttributeValue, transformData[12:12+attributeLength])
 				} else {
+					if len(transformData) < 12 {
+                        return errors.Errorf("Transform: attribute data too short to read Value (length: %d)", len(transformData))
+                    }
+					
 					transform.AttributeValue = binary.BigEndian.Uint16(transformData[10:12])
 				}
 			}


### PR DESCRIPTION
### Description
This PR addresses malformed transform attribute data with insufficient length.
This issue was tracked in [issue #940](https://github.com/free5gc/free5gc/issues/940)

### Changes
- Added boundary validation checks.
- Returns a controlled decoder error if the length is insufficien.