### PR TITLE
Fix empty payload list

### DIFF
--- a/eap/eap.go
+++ b/eap/eap.go
@@ -141,6 +141,11 @@ func (eap *EAP) Unmarshal(b []byte) error {
 		eap.Code = EapCode(b[0])
 		eap.Identifier = b[1]
 
+		// EAP Request or Response
+		if (eap.Code == EapCodeRequest || eap.Code == EapCodeResponse) && eapPayloadLength < 5 {
+			return errors.New("EAP payload too short for Request/Response: length")
+		}
+
 		// EAP Success or Failure
 		if eapPayloadLength == 4 {
 			return nil

--- a/ike.go
+++ b/ike.go
@@ -49,7 +49,8 @@ func DecodeDecrypt(
 		}
 	}
 
-	if ikeMsg.Payloads[0].Type() == message.TypeSK {
+	// Check payload is not empty and the first payload is Encrypted, then decrypt the message
+	if len(ikeMsg.Payloads) > 0 && ikeMsg.Payloads[0].Type() == message.TypeSK {
 		if ikesaKey == nil {
 			return nil, errors.Errorf("IKE decode decrypt: need ikesaKey to decrypt")
 		}

--- a/message/message.go
+++ b/message/message.go
@@ -55,6 +55,11 @@ func (m *IKEMessage) Decode(b []byte) error {
 }
 
 func (m *IKEMessage) DecodePayload(b []byte) error {
+	// If NextPayload is not 0 but payload bytes are empty, it's a malformed message
+	if m.NextPayload != 0 && len(b) == 0 {
+		return errors.Errorf("DecodePayload(): NextPayload is %d but payloadbytes are empty", m.NextPayload)
+	}
+
 	err := m.Payloads.Decode(m.NextPayload, b)
 	if err != nil {
 		return errors.Errorf("DecodePayload(): DecodePayload failed: %v", err)

--- a/message/payload_securityassociation.go
+++ b/message/payload_securityassociation.go
@@ -199,8 +199,8 @@ func (securityAssociation *SecurityAssociation) Unmarshal(b []byte) error {
 			transform.TransformID = binary.BigEndian.Uint16(transformData[6:8])
 			if transformLength > 8 {
 				if len(transformData) < 10 {
-                    return errors.Errorf("Transform: attribute data too short to read Type (length: %d)", len(transformData))
-                }
+					return errors.Errorf("Transform: attribute data too short to read Type (length: %d)", len(transformData))
+				}
 
 				transform.AttributePresent = true
 				transform.AttributeFormat = ((transformData[8] & 0x80) >> 7)
@@ -208,8 +208,8 @@ func (securityAssociation *SecurityAssociation) Unmarshal(b []byte) error {
 
 				if transform.AttributeFormat == 0 {
 					if len(transformData) < 12 {
-                        return errors.Errorf("Transform: attribute data too short to read Length (length: %d)", len(transformData))
-                    }
+						return errors.Errorf("Transform: attribute data too short to read Length (length: %d)", len(transformData))
+					}
 
 					attributeLength := binary.BigEndian.Uint16(transformData[10:12])
 					// bounds checking
@@ -220,9 +220,9 @@ func (securityAssociation *SecurityAssociation) Unmarshal(b []byte) error {
 					copy(transform.VariableLengthAttributeValue, transformData[12:12+attributeLength])
 				} else {
 					if len(transformData) < 12 {
-                        return errors.Errorf("Transform: attribute data too short to read Value (length: %d)", len(transformData))
-                    }
-					
+						return errors.Errorf("Transform: attribute data too short to read Value (length: %d)", len(transformData))
+					}
+
 					transform.AttributeValue = binary.BigEndian.Uint16(transformData[10:12])
 				}
 			}

--- a/message/payload_securityassociation.go
+++ b/message/payload_securityassociation.go
@@ -198,11 +198,19 @@ func (securityAssociation *SecurityAssociation) Unmarshal(b []byte) error {
 			transform.TransformType = transformData[4]
 			transform.TransformID = binary.BigEndian.Uint16(transformData[6:8])
 			if transformLength > 8 {
+				if len(transformData) < 10 {
+                    return errors.Errorf("Transform: attribute data too short to read Type (length: %d)", len(transformData))
+                }
+
 				transform.AttributePresent = true
 				transform.AttributeFormat = ((transformData[8] & 0x80) >> 7)
 				transform.AttributeType = binary.BigEndian.Uint16(transformData[8:10]) & 0x7f
 
 				if transform.AttributeFormat == 0 {
+					if len(transformData) < 12 {
+                        return errors.Errorf("Transform: attribute data too short to read Length (length: %d)", len(transformData))
+                    }
+
 					attributeLength := binary.BigEndian.Uint16(transformData[10:12])
 					// bounds checking
 					if (12 + attributeLength) != transformLength {
@@ -211,6 +219,10 @@ func (securityAssociation *SecurityAssociation) Unmarshal(b []byte) error {
 					}
 					copy(transform.VariableLengthAttributeValue, transformData[12:12+attributeLength])
 				} else {
+					if len(transformData) < 12 {
+                        return errors.Errorf("Transform: attribute data too short to read Value (length: %d)", len(transformData))
+                    }
+					
 					transform.AttributeValue = binary.BigEndian.Uint16(transformData[10:12])
 				}
 			}


### PR DESCRIPTION
### Description

This PR addresses a panic in the IKE decoder when processing malformed packets.
This issue is related to the root cause described in [issue #968.](https://github.com/free5gc/free5gc/issues/968)

### Changes
- Added a validation check for payload before accessing the first payload.
- Added a check to ensure the payload buffer is not empty when NextPayload is non-zero.