### PR TITLE
fix: validate received Diffie-Hellman public values

### DIFF
--- a/security/dh/dh.go
+++ b/security/dh/dh.go
@@ -91,6 +91,6 @@ func ToTransform(dhType DHType) *message.Transform {
 type DHType interface {
 	TransformID() uint16
 	getAttribute() (bool, uint16, uint16, []byte)
-	GetSharedKey(secret, peerPublicValue *big.Int) []byte
+	GetSharedKey(secret, peerPublicValue *big.Int) ([]byte, error)
 	GetPublicValue(secret *big.Int) []byte
 }

--- a/security/dh/dh_1024_bit_modp.go
+++ b/security/dh/dh_1024_bit_modp.go
@@ -3,6 +3,8 @@ package dh
 import (
 	"math/big"
 
+	"github.com/pkg/errors"
+
 	"github.com/free5gc/ike/message"
 )
 
@@ -39,11 +41,20 @@ func (t *Dh1024BitModp) getAttribute() (bool, uint16, uint16, []byte) {
 	return false, 0, 0, nil
 }
 
-func (t *Dh1024BitModp) GetSharedKey(secret, peerPublicValue *big.Int) []byte {
+func (t *Dh1024BitModp) GetSharedKey(secret, peerPublicValue *big.Int) ([]byte, error) {
+	// Validate peerPublicValue: must be in the range (1, p-1)
+	one := big.NewInt(1)
+	pMinusOne := new(big.Int).Sub(t.factor, one)
+
+	// if peerPublicValue <= 1 or peerPublicValue >= p-1
+	if peerPublicValue.Cmp(one) <= 0 || peerPublicValue.Cmp(pMinusOne) >= 0 {
+		return nil, errors.New("invalid DH public value.")
+	}
+
 	sharedKey := new(big.Int).Exp(peerPublicValue, secret, t.factor).Bytes()
 	prependZero := make([]byte, t.factorBytesLength-len(sharedKey))
 	sharedKey = append(prependZero, sharedKey...)
-	return sharedKey
+	return sharedKey, nil
 }
 
 func (t *Dh1024BitModp) GetPublicValue(secret *big.Int) []byte {

--- a/security/dh/dh_2048_bit_modp.go
+++ b/security/dh/dh_2048_bit_modp.go
@@ -3,6 +3,8 @@ package dh
 import (
 	"math/big"
 
+	"github.com/pkg/errors"
+
 	"github.com/free5gc/ike/message"
 )
 
@@ -47,11 +49,19 @@ func (t *DH2048BitModp) getAttribute() (bool, uint16, uint16, []byte) {
 	return false, 0, 0, nil
 }
 
-func (t *DH2048BitModp) GetSharedKey(secret, peerPublicValue *big.Int) []byte {
+func (t *DH2048BitModp) GetSharedKey(secret, peerPublicValue *big.Int) ([]byte, error) {
+	// Validate peerPublicValue: must be in the range (1, p-1)
+	one := big.NewInt(1)
+	pMinusOne := new(big.Int).Sub(t.factor, one)
+
+	// if peerPublicValue <= 1 or peerPublicValue >= p-1
+	if peerPublicValue.Cmp(one) <= 0 || peerPublicValue.Cmp(pMinusOne) >= 0 {
+		return nil, errors.New("invalid DH public value.")
+	}
 	sharedKey := new(big.Int).Exp(peerPublicValue, secret, t.factor).Bytes()
 	prependZero := make([]byte, t.factorBytesLength-len(sharedKey))
 	sharedKey = append(prependZero, sharedKey...)
-	return sharedKey
+	return sharedKey, nil
 }
 
 func (t *DH2048BitModp) GetPublicValue(secret *big.Int) []byte {

--- a/security/security.go
+++ b/security/security.go
@@ -203,7 +203,12 @@ func CalculateDiffieHellmanMaterials(
 	}
 
 	peerPublicValueBig := new(big.Int).SetBytes(peerPublicValue)
-	return ikesaKey.DhInfo.GetPublicValue(secret), ikesaKey.DhInfo.GetSharedKey(secret, peerPublicValueBig), nil
+	sharedKey, err := ikesaKey.DhInfo.GetSharedKey(secret, peerPublicValueBig)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "CalculateDiffieHellmanMaterials() failed to get shared key")
+	}
+
+	return ikesaKey.DhInfo.GetPublicValue(secret), sharedKey, nil
 }
 
 func (ikesaKey *IKESAKey) GenerateKeyForIKESA(


### PR DESCRIPTION
### Description
This PR fixes a security vulnerability in N3IWF and TNGF where Diffie-Hellman public values are not validated before shared secret computation.
Treat out-of-bound DH public values as invalid according to RFC 6989, and safely abort the IKE SA initialization to prevent zero-cost key recovery attacks.
This issue is tracked in [issue #972](https://github.com/free5gc/free5gc/issues/972) .

### Changes

- Added boundary checks (1 < Y < p - 1) for peer public values in DH group implementations.
- Updated GetSharedKey return signature and DhInfo interface to propagate errors.
- Handled validation errors in CalculateDiffieHellmanMaterials to reject malformed packets.