### PR TITLE
fix: validate AES-CBC padding length to prevent remote DoS panic

### DIFF
--- a/security/encr/encr_aes_cbc.go
+++ b/security/encr/encr_aes_cbc.go
@@ -4,6 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"fmt"
 	"io"
 
 	"github.com/pkg/errors"
@@ -147,6 +148,9 @@ func (encr *EncrAesCbcCrypto) Decrypt(cipherText []byte) ([]byte, error) {
 	// fmt.Printf("Decrypted content:\n%s", hex.Dump(plainText))
 	// Remove padding
 	padding := int(plainText[len(plainText)-1]) + 1
+	if padding > len(plainText) {
+		return nil, fmt.Errorf("invalid padding length %d exceeds plaintext length %d", padding, len(plainText))
+	}
 	plainText = plainText[:len(plainText)-padding]
 
 	// fmt.Printf("Decrypted content with out padding:\n%s", hex.Dump(plainText))


### PR DESCRIPTION
## Security Fix

Fixes free5gc/free5gc#997, free5gc/free5gc#998

### Vulnerability

A remote attacker can crash the N3IWF/TNGF process by sending a crafted IKE_AUTH message with an invalid padding byte:

```go
// encr_aes_cbc.go:149-150
padding := int(plainText[len(plainText)-1]) + 1     // attacker controls this
plainText = plainText[:len(plainText)-padding]       // PANIC: negative slice
```

When the last decrypted byte is >= 0x10 (e.g. 0xFF → padding=256), the slice operation panics. The server's `recover()` calls `Fatalf` → `os.Exit(1)`, killing the process.

**Attack requires only IKE_SA_INIT completion (one UDP round-trip). No SIM/auth needed.**

### Fix

Validate padding length before slicing:

```go
if padding > len(plainText) {
    return nil, fmt.Errorf("invalid padding length %d exceeds plaintext length %d", padding, len(plainText))
}
```